### PR TITLE
swap gmmktime to strtotime

### DIFF
--- a/app/lib/ucam_webauth.php
+++ b/app/lib/ucam_webauth.php
@@ -381,13 +381,7 @@ class Ucam_Webauth {
   }
 
   function iso2time($t) {
-    return gmmktime(substr($t, 9, 2),
-		    substr($t, 11, 2),
-		    substr($t, 13, 2),
-		    substr($t, 4, 2),
-		    substr($t, 6, 2),
-		    substr($t, 0, 4),
-		    -1);
+    return strtotime($t);
   }
 
   function wls_encode($str) {


### PR DESCRIPTION
is_dst in gmmktime is deprecated and causes crash if included on some PHP versions